### PR TITLE
Add link to PaymentSpring API in layout

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -13,5 +13,6 @@
   <div class="container"> 
     @yield('content')
   </div>
+  <h4 align="center">Made with the <a href="https://paymentspring.com/developers/" target="_blank">PaymentSpring API</a></h4>
 </body>
 </html>


### PR DESCRIPTION
Similar to the Rails app, I felt it would be nice to have a link to the actual PaymentSpring website on the app. This inserts a link at the bottom of every page, like so:

<img width="1085" alt="branding" src="https://cloud.githubusercontent.com/assets/14966249/26694721/07a0fec4-46ce-11e7-9404-b5b6a678f091.png">
